### PR TITLE
Allow commands to initiate a prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Extension to execute Drush commands in [Robo](https://github.com/Codegyre/Robo).
 
 Runs Drush commands in stack. You can define global options for all commands (like Drupal root and uri).
 
-The option -y is always set, as it makes sense in a task runner.
+The option -y assumed by default but can be overridden on calls to `exec()` by passing `false` as the second parameter.
 
 ## Table of contents
 

--- a/src/DrushStack.php
+++ b/src/DrushStack.php
@@ -317,26 +317,28 @@ class DrushStack extends CommandStack
      * Runs the given drush command.
      *
      * @param string $command
+     * @param bool $prompt
      * @return $this
      */
-    public function exec($command)
+    public function exec($command, $assumeYes = true)
     {
         if (is_array($command)) {
             $command = implode(' ', array_filter($command));
         }
 
-        return parent::exec($this->injectArguments($command));
+        return parent::exec($this->injectArguments($command, $assumeYes));
     }
 
-    /**
-     * Prepends site-alias and appends arguments to the command.
-     *
-     * @param string $command
-     * @return string the modified command string
-     */
-    protected function injectArguments($command)
+  /**
+   * Prepends site-alias and appends arguments to the command.
+   *
+   * @param string $command
+   * @param bool $assumeYes
+   * @return string the modified command string
+   */
+    protected function injectArguments($command, $assumeYes)
     {
-        return $this->siteAlias . ' ' . $command . ' -y' . $this->arguments;
+        return $this->siteAlias . ' ' . $command . ($assumeYes ? ' -y' : '') . $this->arguments;
     }
 
 }

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -12,6 +12,14 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('drush command -y', $command);
     }
 
+    public function testAbsenceofYes()
+    {
+        $command = $this->taskDrushStack()
+                        ->exec('command', false)
+                        ->getCommand();
+        $this->assertEquals('drush command', $command);
+    }
+
     public function testOptionsArePrependedBeforeEachCommand()
     {
         $command = $this->taskDrushStack()


### PR DESCRIPTION
Assuming -y is a really good default, but adding the flexibility to remove it is trivial and increases flexibility.
