### PR TITLE
Update for Robo 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - '7'
   - 5.6
   - 5.5
-  - 5.4
 install:
   - composer self-update
   - composer install

--- a/README.md
+++ b/README.md
@@ -47,14 +47,6 @@ class RoboFile extends \Robo\Tasks
 
     // if you use ~1.0 for Robo ~0.4
     use \Boedah\Robo\Task\Drush;
-
-    // include for Robo >=1.0.0
-    public function getServiceProviders()
-    {
-        return [
-            \Boedah\Robo\Task\Drush\loadTasks::getDrushServices(),
-        ];
-    }
     
     //...
 }

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ The option -y assumed by default but can be overridden on calls to `exec()` by p
 
 - `~1.0`: Robo <= 0.4.5
 - `~2.1`: Robo >= 0.5.2
+- '~3.0': Robo >= 1.0.0-RC1
 
-Add `"boedah/robo-drush": "~2.1"` to your composer.json:
+Add `"boedah/robo-drush": "~3"` to your composer.json:
 
 ```json
     {
         "require-dev": {
-            "boedah/robo-drush": "~2.1"
+            "boedah/robo-drush": "~3"
         }
     }
 ```
@@ -41,12 +42,20 @@ Use the trait (according to your used version) in your RoboFile:
 ```php
 class RoboFile extends \Robo\Tasks
 {
-    // if you use ~2.1 for Robo >=0.5.2
+    // if you use ~2.1 for Robo >=0.5.2, or ~3 for Robo >=1.0.0-RC1
     use \Boedah\Robo\Task\Drush\loadTasks;
 
     // if you use ~1.0 for Robo ~0.4
     use \Boedah\Robo\Task\Drush;
 
+    // include for Robo >=1.0.0
+    public function getServiceProviders()
+    {
+        return [
+            \Boedah\Robo\Task\Drush\loadTasks::getDrushServices(),
+        ];
+    }
+    
     //...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The option -y assumed by default but can be overridden on calls to `exec()` by p
 
 - [Versions](#versions)
 - [Installation](#installation)
+- [Testing](#testing)
 - [Usage](#usage)
 - [Examples](#examples)
 
@@ -34,6 +35,10 @@ Add `"boedah/robo-drush": "~3"` to your composer.json:
 ```
 
 Execute `composer update`.
+
+## Testing
+
+`composer test`
 
 ## Usage
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -13,6 +13,7 @@ class RoboFile extends \Robo\Tasks
             ->option('strict-coverage')
             ->option('-v')
             ->option('-d error_reporting=-1')
+            ->bootstrap('vendor/autoload.php')
             ->arg('tests')
             ->run();
     }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "consolidation/Robo": "dev-master"
+        "consolidation/Robo": "^1.0.0-RC2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "boedah/robo-drush",
+    "name": "greg-1-anderson/robo-drush",
     "description": "Drush CommandStack for Robo Task Runner",
     "type": "robo-tasks",
     "license": "MIT",
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "consolidation/robo": "dev-master"
+        "consolidation/Robo": "dev-remove-services"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "greg-1-anderson/robo-drush",
+    "name": "boedah/robo-drush",
     "description": "Drush CommandStack for Robo Task Runner",
     "type": "robo-tasks",
     "license": "MIT",
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "consolidation/Robo": "dev-remove-services"
+        "consolidation/Robo": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "boedah/robo-drush",
     "description": "Drush CommandStack for Robo Task Runner",
+    "type": "robo-tasks",
     "license": "MIT",
     "authors": [
         {
@@ -14,11 +15,14 @@
         }
     },
     "require": {
-        "php": ">=5.4.0",
-        "codegyre/robo": ">=0.5.2"
+        "php": ">=5.5.0",
+        "consolidation/robo": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",
-        "drush/drush": "~6.5"
+        "drush/drush": "~8"
+    },
+    "suggest": {
+        "drush/drush": "robo-drush needs a global or local Drush to use."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "email": "dev@boedah.de"
         }
     ],
+    "scripts": {
+        "test": "robo --ansi test"
+    },
     "autoload": {
         "psr-4": {
             "Boedah\\Robo\\Task\\Drush\\": "src"
@@ -16,7 +19,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "consolidation/Robo": "^1.0.0-RC2"
+        "consolidation/Robo": "~1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",

--- a/src/loadTasks.php
+++ b/src/loadTasks.php
@@ -2,14 +2,28 @@
 
 namespace Boedah\Robo\Task\Drush;
 
+use Robo\Container\SimpleServiceProvider;
+
 trait loadTasks
 {
+    /**
+     * Return services.
+     */
+    public static function getDrushServices()
+    {
+        return new SimpleServiceProvider(
+            [
+                'taskDrushStack' => DrushStack::class,
+            ]
+        );
+    }
+
     /**
      * @param string $pathToDrush
      * @return DrushStack
      */
     protected function taskDrushStack($pathToDrush = 'drush')
     {
-        return new DrushStack($pathToDrush);
+        return $this->task(__FUNCTION__, $pathToDrush);
     }
 }

--- a/src/loadTasks.php
+++ b/src/loadTasks.php
@@ -2,28 +2,14 @@
 
 namespace Boedah\Robo\Task\Drush;
 
-use Robo\Container\SimpleServiceProvider;
-
 trait loadTasks
 {
-    /**
-     * Return services.
-     */
-    public static function getDrushServices()
-    {
-        return new SimpleServiceProvider(
-            [
-                'taskDrushStack' => DrushStack::class,
-            ]
-        );
-    }
-
     /**
      * @param string $pathToDrush
      * @return DrushStack
      */
     protected function taskDrushStack($pathToDrush = 'drush')
     {
-        return $this->task(__FUNCTION__, $pathToDrush);
+        return $this->task(DrushStack::class, $pathToDrush);
     }
 }

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -15,8 +15,15 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
     // Set up the Robo container so that we can create tasks in our tests.
     function setup()
     {
-        $container = Robo::createDefaultContainer(null, new NullOutput(), [ \Boedah\Robo\Task\Drush\loadTasks::getDrushServices() ]);
+        $container = Robo::createDefaultContainer(null, new NullOutput());
         $this->setContainer($container);
+    }
+
+    // Scaffold the collection builder
+    public function collectionBuilder()
+    {
+        $emptyRobofile = new \Robo\Tasks;
+        return $this->getContainer()->get('collectionBuilder', [$emptyRobofile]);
     }
 
     public function testYesIsAssumed()

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -1,13 +1,28 @@
 <?php
 
-class DrushStackTest extends \PHPUnit_Framework_TestCase
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Symfony\Component\Console\Output\NullOutput;
+use Robo\TaskAccessor;
+use Robo\Robo;
+
+class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwareInterface
 {
-    use Boedah\Robo\Task\Drush\loadTasks;
+    use \Boedah\Robo\Task\Drush\loadTasks;
+    use TaskAccessor;
+    use ContainerAwareTrait;
+
+    // Set up the Robo container so that we can create tasks in our tests.
+    function setup()
+    {
+        $container = Robo::createDefaultContainer(null, new NullOutput(), [ \Boedah\Robo\Task\Drush\loadTasks::getDrushServices() ]);
+        $this->setContainer($container);
+    }
 
     public function testYesIsAssumed()
     {
         $command = $this->taskDrushStack()
-            ->exec('command')
+            ->drush('command')
             ->getCommand();
         $this->assertEquals('drush command -y', $command);
     }
@@ -15,8 +30,8 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase
     public function testAbsenceofYes()
     {
         $command = $this->taskDrushStack()
-                        ->exec('command', false)
-                        ->getCommand();
+            ->drush('command', false)
+            ->getCommand();
         $this->assertEquals('drush command', $command);
     }
 
@@ -24,8 +39,8 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase
     {
         $command = $this->taskDrushStack()
             ->drupalRootDirectory('/var/www/html/app')
-            ->exec('command-1')
-            ->exec('command-2')
+            ->drush('command-1')
+            ->drush('command-2')
             ->getCommand();
         $this->assertEquals(2, preg_match_all('#-r /var/www/html/app#', $command));
     }
@@ -58,8 +73,8 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase
         $command = $this->taskDrushStack()
             ->drupalRootDirectory('/var/www/html/app')
             ->siteAlias('@qa')
-            ->exec('command-1')
-            ->exec('command-2')
+            ->drush('command-1')
+            ->drush('command-2')
             ->getCommand();
         $this->assertEquals(2, preg_match_all('#drush @qa comm#', $command));
     }


### PR DESCRIPTION
- Update taskDrushStack to follow standard pattern used in Robo 1.0.0.
- Add a getDrushServices() method to loadTasks to advertise task services.
- Ensure that Drush options that are only intended to be attached to the next Drush task are cleared, so that they are not inadvertantly applied to following tasks.

This PR presumes that you will tag a 3.0 build after this is merged.
