### PR TITLE
Test multiple drush versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "minimum-stability": "beta",
     "require": {
         "php": ">=5.5.0",
-        "consolidation/Robo": "~1",
-        "drush/drush": "^8.0 | ^9.0"
+        "consolidation/Robo": "~1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4"
+        "phpunit/phpunit": "~4.4",
+        "drush/drush": "^8.0 | ^9.0"
     },
     "suggest": {
         "drush/drush": "robo-drush needs a global or local Drush to use."

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,14 @@
             "Boedah\\Robo\\Task\\Drush\\": "src"
         }
     },
+    "minimum-stability": "beta",
     "require": {
         "php": ">=5.5.0",
-        "consolidation/Robo": "~1"
+        "consolidation/Robo": "~1",
+        "drush/drush": "^8.0 | ^9.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.4",
-        "drush/drush": "8.1.12"
+        "phpunit/phpunit": "~4.4"
     },
     "suggest": {
         "drush/drush": "robo-drush needs a global or local Drush to use."

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -112,17 +112,17 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
 
     public function testDrushVersion()
     {
-        foreach (['8.1.15' => '8.1.15', '9.0.0-rc1' => '9.0.0'] as $version => $version_string) {
-            if (version_compare('5.6', phpversion()) > 0 && version_compare($version_string, '9.0') > 0) {
+        foreach (['8.1.15' => '8.1.15', '9.0.0-rc1' => '9.0.0'] as $composerDrushVersion => $expectedVersion) {
+            if (version_compare('5.6', phpversion()) > 0 && version_compare($expectedVersion, '9.0') > 0) {
               continue;
             }
 
             $this->ensureDirectoryExistsAndClear($this->tmpDir);
             $this->writeComposerJSON();
-            $this->composer('require --update-with-dependencies drush/drush:"' . $version . '"');
-            $version2 = $this->taskDrushStack($this->tmpDir . '/vendor/bin/drush')
+            $this->composer('require --update-with-dependencies drush/drush:"' . $composerDrushVersion . '"');
+            $actualVersion = $this->taskDrushStack($this->tmpDir . '/vendor/bin/drush')
               ->getVersion();
-            $this->assertEquals($version_string, $version2);
+            $this->assertEquals($expectedVersion, $actualVersion);
         }
     }
 

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -113,7 +113,9 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
     public function testDrushVersion()
     {
         foreach (['8.1.15' => '8.1.15', '9.0.0-rc1' => '9.0.0'] as $version => $version_string) {
-            if (version_compare('5.6', phpversion()) > 0 && version_compare($version_string, '9.0') > 0) continue;
+            if (version_compare('5.6', phpversion()) > 0 && version_compare($version_string, '9.0') > 0) {
+              continue;
+            }
 
             $this->ensureDirectoryExistsAndClear($this->tmpDir);
             $this->writeComposerJSON();

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -173,7 +173,7 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
       if (is_dir($directory)) {
         $this->fs->remove($directory);
       }
-      mkdir($directory, 0777, true);
+      $this->fs->mkdir($directory, 0777);
     }
 
 }

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -14,7 +14,7 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
     use ContainerAwareTrait;
 
     /**
-     * @var \Symfony\Component\Filesystem\Filesystem
+     * @var Filesystem
      */
     protected $fs;
 

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -142,9 +142,6 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
      */
     protected function composerJSONDefaults() {
       return array(
-        'require' => array(
-          'drush/drush' => '^8.0 | ^9.0'
-        ),
         'minimum-stability' => 'beta'
       );
     }

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -117,7 +117,7 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
 
     public function testDrushVersion()
     {
-        foreach (['8.1.12' => '8.1.12', '9.0.0-beta3' => '9.0.0'] as $version => $version_string) {
+        foreach (['8.1.15' => '8.1.15', '9.0.0-rc1' => '9.0.0'] as $version => $version_string) {
             $this->ensureDirectoryExistsAndClear($this->tmpDir);
             $this->writeComposerJSON();
             $this->composer('require --update-with-dependencies drush/drush:"' . $version .'" -vvv');

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -119,7 +119,7 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
 
             $this->ensureDirectoryExistsAndClear($this->tmpDir);
             $this->writeComposerJSON();
-            $this->composer('require --update-with-dependencies drush/drush:"' . $version .'" -vvv');
+            $this->composer('require --update-with-dependencies drush/drush:"' . $version . '"');
             $version2 = $this->taskDrushStack($this->tmpDir . '/vendor/bin/drush')
               ->getVersion();
             $this->assertEquals($version_string, $version2);

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -23,11 +23,6 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
      */
     protected $tmpDir;
 
-    /**
-     * @var string
-     */
-    protected $tmpReleaseTag;
-
     // Set up the Robo container so that we can create tasks in our tests.
     public function setUp()
     {

--- a/tests/DrushStackTest.php
+++ b/tests/DrushStackTest.php
@@ -118,6 +118,8 @@ class DrushStackTest extends \PHPUnit_Framework_TestCase implements ContainerAwa
     public function testDrushVersion()
     {
         foreach (['8.1.15' => '8.1.15', '9.0.0-rc1' => '9.0.0'] as $version => $version_string) {
+            if (version_compare('5.6', phpversion()) > 0 && version_compare($version_string, '9.0') > 0) continue;
+
             $this->ensureDirectoryExistsAndClear($this->tmpDir);
             $this->writeComposerJSON();
             $this->composer('require --update-with-dependencies drush/drush:"' . $version .'" -vvv');


### PR DESCRIPTION
Fixes #7 
Fixes #9 
Also adds a version constraint on drush/drush, since that package is needed to use robo-drush, and this way support can be tested pro-actively better.