### PR TITLE
Expose the existing-config option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- possibility to test multiple drush versions
+- Possibility to test multiple drush versions.
+- Support to install from existing config.
 
 ## [4.0.0] - 2018-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Possibility to test multiple drush versions.
-- Support to install from existing config.
+- possibility to test multiple drush versions
 
 ## [4.0.0] - 2018-09-11
 

--- a/src/DrushStack.php
+++ b/src/DrushStack.php
@@ -237,6 +237,13 @@ class DrushStack extends CommandStack
         return $this;
     }
 
+    public function existingConfig()
+    {
+        $this->argForNextCommand('--existing-config');
+
+        return $this;
+    }
+
     /**
      * Executes `drush status`
      *

--- a/src/DrushStack.php
+++ b/src/DrushStack.php
@@ -237,9 +237,11 @@ class DrushStack extends CommandStack
         return $this;
     }
 
-    public function existingConfig()
+    public function existingConfig($existingConfig = false)
     {
-        $this->argForNextCommand('--existing-config');
+        if ($existingConfig) {
+            $this->argForNextCommand('--existing-config');
+        }
 
         return $this;
     }

--- a/src/DrushStack.php
+++ b/src/DrushStack.php
@@ -237,7 +237,7 @@ class DrushStack extends CommandStack
         return $this;
     }
 
-    public function existingConfig($existingConfig = false)
+    public function existingConfig($existingConfig = true)
     {
         if ($existingConfig) {
             $this->argForNextCommand('--existing-config');


### PR DESCRIPTION
--existing-config is now an optional parameter, it will import config from the configured sync folder after install.

See this change record: https://www.drupal.org/node/2897299

This PR solves #13.